### PR TITLE
Report connection up immediately on headers received

### DIFF
--- a/lib/protocol/dispatcher.js
+++ b/lib/protocol/dispatcher.js
@@ -149,6 +149,9 @@ Dispatcher.prototype = {
       envelope.resolve = resolve;
     });
 
+    var start = Date.now();
+    var timeout = scheduler.getTimeout();
+
     // 1. Obtain transport
     return this._pool.get()
       .bind(this)
@@ -157,9 +160,9 @@ Dispatcher.prototype = {
         message = this._enrich(message, transport);
         debug('attemptSend: %j', message);
 
-        return transport.sendMessage(message);
+        return transport.sendMessage(message)
+          .timeout(this._advice.getConnectTimeout(), 'Timeout on message send');
       })
-      .timeout(scheduler.getTimeout(), 'Timeout on message send')
       .catch(function(e) {
         this._triggerDown();
         throw e;
@@ -167,8 +170,10 @@ Dispatcher.prototype = {
       .then(function() {
         this._triggerUp();
 
+        var remaining = timeout - (Date.now() - start);
+
         // 3. Wait for the response from the transport
-        return responsePromise;
+        return responsePromise.timeout(remaining, 'Timeout on message response');
       })
       .then(function(response) {
         // 4. Parse the response
@@ -183,7 +188,6 @@ Dispatcher.prototype = {
 
         return response;
       })
-      .timeout(scheduler.getTimeout(), 'Timeout on message response')
       .finally(function() {
         envelope.resolve = null;
       })

--- a/lib/protocol/dispatcher.js
+++ b/lib/protocol/dispatcher.js
@@ -14,6 +14,9 @@ var globalEvents   = require('../util/global-events');
 var HANDSHAKE = 'handshake';
 var BAYEUX_VERSION = '1.0';
 
+var STATE_UP = 1;
+var STATE_DOWN = 2;
+
 /**
  * The dispatcher sits between the client and the transport.
  *
@@ -31,9 +34,6 @@ function Dispatcher(endpoint, advice, options) {
 }
 
 Dispatcher.prototype = {
-
-  UP: 1,
-  DOWN: 2,
 
   destroy: function() {
     debug('destroy');
@@ -142,82 +142,52 @@ Dispatcher.prototype = {
     if (!scheduler.isDeliverable()) {
       return Promise.reject(new Error('No longer deliverable'));
     }
-    var isConnectMessage = message.channel === Channel.CONNECT;
 
     scheduler.send();
+
+    var responsePromise = new Promise(function(resolve/*, reject, onCancel*/) {
+      envelope.resolve = resolve;
+    });
+
+    // 1. Obtain transport
     return this._pool.get()
       .bind(this)
-      .timeout(scheduler.getTimeout(), 'Timeout awaiting transport')
       .then(function(transport) {
+        // 2. Send the message using the given transport
         message = this._enrich(message, transport);
         debug('attemptSend: %j', message);
 
-        var sendPromise = transport.sendMessage(message)
-          .bind(this)
-          .then(function() {
-            // Note that if the send has other listeners
-            // for example on batched transports, we need to
-            // chain the promise in order to prevent other
-            // listeners from being cancelled.
-            // In other words, the send will only
-            // cancel if all the subscribers cancel it
-            if (isConnectMessage) {
-              if (this._state !== this.UP) {
-                this._state = this.UP;
-                this.trigger('transport:up');
-
-                // If we've disable websockets due to a network
-                // outage, try re-enable them now
-                this._pool.reevaluate();
-              }
-            }
-
-            return null;
-          });
-
-        // If the response didn't win the race we know that we have a
-        // transport
-        return new Promise(function(resolve, reject, onCancel) {
-          envelope.resolve = resolve;
-
-          // If the send fails
-          sendPromise.catch(function(err) {
-            reject(err);
-          });
-
-          onCancel(function() {
-            sendPromise.cancel();
-          });
-        })
-        .timeout(scheduler.getTimeout(), 'Timeout awaiting message response')
-        .catch(Promise.TimeoutError, function(err) {
-          // Cancel the send
-          sendPromise.cancel();
-
-          throw err;
-        })
-        .then(function(response) {
-          if (response.successful === false && response.advice && response.advice.reconnect === HANDSHAKE) {
-            // This is not standard, and may need a bit of reconsideration
-            // but if the client sends a message to the server and the server responds with
-            // an error and tells the client it needs to rehandshake,
-            // reschedule the send after the send after the handshake has occurred.
-            throw new Error('Message send failed with advice reconnect:handshake, will reschedule send');
-          }
-          return response;
-        })
-        .finally(function() {
-          envelope.resolve = null;
-        });
+        return transport.sendMessage(message);
       })
+      .timeout(scheduler.getTimeout(), 'Timeout on message send')
       .catch(function(e) {
-        if (isConnectMessage) {
-          if (this._state !== this.DOWN) {
-            this._state = this.DOWN;
-            this.trigger('transport:down');
-          }
+        this._triggerDown();
+        throw e;
+      })
+      .then(function() {
+        this._triggerUp();
+
+        // 3. Wait for the response from the transport
+        return responsePromise;
+      })
+      .then(function(response) {
+        // 4. Parse the response
+
+        if (response.successful === false && response.advice && response.advice.reconnect === HANDSHAKE) {
+          // This is not standard, and may need a bit of reconsideration
+          // but if the client sends a message to the server and the server responds with
+          // an error and tells the client it needs to rehandshake,
+          // reschedule the send after the send after the handshake has occurred.
+          throw new Error('Message send failed with advice reconnect:handshake, will reschedule send');
         }
 
+        return response;
+      })
+      .timeout(scheduler.getTimeout(), 'Timeout on message response')
+      .finally(function() {
+        envelope.resolve = null;
+      })
+      .catch(function(e) {
         debug('Error while attempting to send message: %j: %s', message, e && e.stack || e);
 
         scheduler.fail();
@@ -225,6 +195,7 @@ Dispatcher.prototype = {
         if (!scheduler.isDeliverable()) {
           throw e;
         }
+
         // Either the send timed out or no transport was
         // available. Either way, wait for the interval and try again
         return this._awaitRetry(envelope, message, scheduler);
@@ -272,8 +243,6 @@ Dispatcher.prototype = {
   },
 
   handleResponse: function(reply) {
-    debug('handleResponse %j', reply);
-
     if (reply.advice) this._advice.update(reply.advice);
     var id = reply.id;
     var envelope = id && this._envelopes[id];
@@ -292,12 +261,36 @@ Dispatcher.prototype = {
     }
   },
 
+  _triggerDown: function() {
+    if (this._state === STATE_DOWN) return;
+    debug('Dispatcher is DOWN');
+
+    this._state = STATE_DOWN;
+    this.trigger('transport:down');
+  },
+
+  _triggerUp: function() {
+    if (this._state === STATE_UP) return;
+    debug('Dispatcher is UP');
+
+    this._state = STATE_UP;
+    this.trigger('transport:up');
+
+    // If we've disable websockets due to a network
+    // outage, try re-enable them now
+    this._pool.reevaluate();
+  },
+
   /**
-   * Currently, this only gets called by streaming transports (websocket)
-   * and let's the dispatcher know that the connection is unavailable
-   * so it needs to switch to an alternative transport
+   * Called by transports on connection error
    */
   transportDown: function(transport) {
+    // If this transport is the current,
+    // report the connection as down
+    if (transport === this._pool.current()) {
+      this._triggerDown();
+    }
+
     this._pool.down(transport);
   }
 };

--- a/lib/protocol/transport-pool.js
+++ b/lib/protocol/transport-pool.js
@@ -39,7 +39,7 @@ TransportPool.prototype = {
   },
 
   current: function() {
-    var c = this._current.get();
+    var c = this._current.peek();
 
     if (c && c.isFulfilled()) {
       return c.value();

--- a/lib/protocol/transport-pool.js
+++ b/lib/protocol/transport-pool.js
@@ -38,6 +38,14 @@ TransportPool.prototype = {
     return cancelBarrier(current);
   },
 
+  current: function() {
+    var c = this._current.get();
+
+    if (c && c.isFulfilled()) {
+      return c.value();
+    }
+  },
+
   /**
    * Set the allowed transport types that `.get` will return
    */

--- a/lib/transport/browser/xhr.js
+++ b/lib/transport/browser/xhr.js
@@ -1,12 +1,12 @@
 'use strict';
 
 var BatchingTransport = require('../batching-transport');
-var globalEvents      = require('../../util/global-events');
 var debug             = require('debug')('halley:xhr');
 var inherits          = require('inherits');
 var extend            = require('../../util/externals').extend;
 var Promise           = require('bluebird');
 
+var XML_HTTP_HEADERS_RECEIVED = 2;
 var XML_HTTP_DONE = 4;
 
 var WindowXMLHttpRequest = window.XMLHttpRequest;
@@ -46,47 +46,53 @@ extend(XHRTransport.prototype, {
 
       function cleanup() {
         if (!xhr) return;
-        globalEvents.off('beforeunload', onUnload, xhr);
         xhr.onreadystatechange = null;
         xhr = null;
       }
 
-      function onUnload() {
-        reject(new Error('Environment unloading'));
-        cleanup();
-      }
-
-      globalEvents.on('beforeunload', onUnload, xhr);
-
       xhr.onreadystatechange = function() {
-        if (!xhr || xhr.readyState !== XML_HTTP_DONE) return;
+        if (!xhr) return;
 
-        var status = xhr.status;
-        var text = xhr.responseText;
+        var readyState = xhr.readyState;
 
-        cleanup();
+        if (readyState !== XML_HTTP_DONE &&
+            readyState !== XML_HTTP_HEADERS_RECEIVED) return;
 
         /**
          * XMLHTTPRequest implementation in MSXML HTTP (at least in IE 8.0 on Windows XP SP3+)
          * does not handle HTTP responses with status code 204 (No Content) properly;
          * the `status' property has the value 1223.
          */
+        var status = xhr.status;
         var successful = (status >= 200 && status < 300) || status === 304 || status === 1223;
-        if (!successful) return reject(new Error('HTTP Status ' + status));
+        if (successful) {
+          resolve();
+        } else {
+          reject(new Error('HTTP Status ' + status));
+          return;
+        }
+
+        if (xhr.readyState == XML_HTTP_HEADERS_RECEIVED) {
+          return;
+        }
+
+        /* readyState is XML_HTTP_DONE */
+        var text = xhr.responseText;
+        cleanup();
 
         var replies;
         try {
           replies = JSON.parse(text);
         } catch (e) {
           debug('Unable to parse XHR response: %s', e);
-          return reject(e);
+          self._dispatcher.transportDown(self);
+          return;
         }
 
         if (replies) {
-          resolve();
           self._receive(replies);
         } else {
-          reject(new Error('No reply'));
+          self._dispatcher.transportDown(self);
         }
       };
 

--- a/lib/transport/node/node-http.js
+++ b/lib/transport/node/node-http.js
@@ -28,7 +28,17 @@ extend(NodeHttpTransport.prototype, {
       var self    = this;
 
       request.on('response', function(response) {
-        var body    = '';
+
+        var status = response.statusCode;
+        var successful = (status >= 200 && status < 300);
+        if (successful) {
+          resolve();
+        } else {
+          reject(new Error('HTTP Status ' + status));
+          return;
+        }
+
+        var body = '';
 
         response.setEncoding('utf8');
         response.on('data', function(chunk) { body += chunk; });
@@ -39,14 +49,14 @@ extend(NodeHttpTransport.prototype, {
           try {
             replies = JSON.parse(body);
           } catch (e) {
-            return reject(e);
+            self._dispatcher.transportDown(self);
+            return;
           }
 
           if (replies) {
-            resolve();
             self._receive(replies);
           } else {
-            return reject(new Error('No reply'));
+            self._dispatcher.transportDown(self);
           }
         });
       });

--- a/lib/util/promise-util.js
+++ b/lib/util/promise-util.js
@@ -60,6 +60,10 @@ LazySingleton.prototype = {
       });
   },
 
+  peek: function() {
+    return this.value;
+  },
+
   clear: function() {
     this.value = null;
   }

--- a/test/client-shutdown-test.js
+++ b/test/client-shutdown-test.js
@@ -6,6 +6,9 @@ var assert = require('assert');
 describe('client-shutdown-test', function() {
 
   it('should cleanup after disconnect', function(done) {
+    // See https://github.com/petkaantonov/bluebird/issues/926
+    this.timeout(45000);
+
     var testProcess = fork(__dirname + '/helpers/cleanup-test-process', [this.urlDirect]);
 
     testProcess.on('close', function (code) {

--- a/test/helpers/cleanup-test-process.js
+++ b/test/helpers/cleanup-test-process.js
@@ -1,7 +1,7 @@
 'use strict';
 
+var wtf     = require('wtfnode'); // Must be first
 var Halley  = require('../..');
-var wtf     = require('wtfnode');
 var Promise = require('bluebird');
 
 var url = process.argv[2];

--- a/test/on-before-unload-test.js
+++ b/test/on-before-unload-test.js
@@ -16,7 +16,7 @@ describe('onbeforeunload', function() {
 
   it('should respond to beforeunload correctly', function(done) {
     var count = 0;
-    var subscription = client.subscribe('/datetime', function(message) {
+    var subscription = client.subscribe('/datetime', function() {
       count++;
 
       if (count === 3) {
@@ -25,7 +25,7 @@ describe('onbeforeunload', function() {
       }
     });
 
-    subscription.catch(function() {
+    subscription.catch(function(err) {
       done(err);
     });
 

--- a/test/specs/client-bad-connection-spec.js
+++ b/test/specs/client-bad-connection-spec.js
@@ -86,6 +86,34 @@ module.exports = function() {
         });
     });
 
+    it('should emit connection events without messages', function() {
+      var client = this.client;
+
+      var d1 = defer();
+      client.on('connection:down', function() {
+        d1.resolve();
+      });
+
+      var d2 = defer();
+      return client.connect()
+        .bind(this)
+        .then(function() {
+          client.on('connection:up', function() {
+            d2.resolve();
+          });
+
+          return this.serverControl.restart();
+        })
+        .then(function() {
+          // connection:down fired
+          return d1.promise;
+        })
+        .then(function() {
+          // connection:up fired
+          return d2.promise;
+        });
+    });
+
   });
 
 };

--- a/test/specs/client-subscribe-spec.js
+++ b/test/specs/client-subscribe-spec.js
@@ -149,13 +149,13 @@ module.exports = function() {
       return this.client.connect()
         .bind(this)
         .then(function() {
-          return this.serverControl.deleteSocket(this.client.getClientId());
+          return this.serverControl.deleteSocket(this.client.getClientId())
+            .delay(100); // Give the server time to disconnect
         })
         .then(function() {
           var d = defer();
 
           var subscribe = this.client.subscribe('/datetime', d.resolve);
-
           return Promise.all([subscribe, d.promise]);
         });
 


### PR DESCRIPTION
The dispatcher is responsible for reporting the status of the transport layer.

When the connection goes down and then resumes (goes up), the implementation will currently only report the transport as being up when a successful response is received from the server.

Unfortunately, this means that if there is little traffic, and the `/meta/connect` message only returns after the `timeout` period, the connection will be reported as being down until the timeout, which is substantially longer than the connection is actually down for.

This change will report the transport as being up when the headers are received from the server (ie, the client has successfully re-established contact with the server)
