### PR TITLE
Better reporting of `connection:up` and `connection:down` events

### DIFF
--- a/lib/mixins/statemachine-mixin.js
+++ b/lib/mixins/statemachine-mixin.js
@@ -126,10 +126,14 @@ var StateMachineMixin = {
   }),
 
   _triggerStateEnter: Promise.method(function(newState, oldState) {
-      var handler = this['_onEnter' + newState];
-      if (handler) {
-        return handler.call(this, oldState);
-      }
+    if (this.onStateChange) {
+      this.onStateChange(newState, oldState);
+    }
+
+    var handler = this['_onEnter' + newState];
+    if (handler) {
+      return handler.call(this, oldState);
+    }
   })
 };
 

--- a/lib/protocol/advice.js
+++ b/lib/protocol/advice.js
@@ -5,7 +5,7 @@ var extend = require('../util/externals').extend;
 var debug  = require('debug')('halley:advice');
 
 var DEFAULT_MAX_NETWORK_DELAY = 30000;
-var DEFAULT_CONNECT_TIMEOUT = 30000;
+var DEFAULT_ESTABLISH_TIMEOUT = 30000;
 var DEFAULT_INTERVAL = 0;
 var DEFAULT_TIMEOUT = 30000;
 var DEFAULT_DISCONNECT_TIMEOUT = 10000;
@@ -13,7 +13,7 @@ var DEFAULT_RETRY_INTERVAL = 1000;
 var DEFAULT_CONNECT_TIMEOUT_PADDING = 500;
 
 var ADVICE_HANDSHAKE = 'handshake';
-var ADVICE_RETRY = 'retry';
+var ADVICE_RETRY = 'retry'; 
 var ADVICE_NONE = 'none';
 
 /**
@@ -22,8 +22,11 @@ var ADVICE_NONE = 'none';
 var HANDSHAKE_FAILURE_THRESHOLD = 3;
 var HANDSHAKE_FAILURE_MIN_INTERVAL = 1000;
 
-var MAX_PING_INTERVAL = 50000; // 50 seconds
+var MAX_PING_INTERVAL = 50000;
 var MIN_PING_INTERVAL = 1000;
+
+var MIN_ESTABLISH_TIMEOUT = 500;
+var MAX_ESTABLISH_TIMEOUT = 60000;
 
 function Advice(options) {
   /* Server controlled values */
@@ -71,10 +74,11 @@ function Advice(options) {
   apply('maxNetworkDelay', DEFAULT_MAX_NETWORK_DELAY);
 
   /**
-   * The maximum number of milliseconds to wait for a WebSocket connection to
-   * be opened. It does not apply to HTTP connections.
+   * The maximum number of milliseconds to wait for an HTTP connection to
+   * be opened, and return headers (but not body). In the case of a
+   * websocket, it's the amount of time to wait for an upgrade
    */
-  apply('connectTimeout', DEFAULT_CONNECT_TIMEOUT);
+  apply('establishTimeout', DEFAULT_ESTABLISH_TIMEOUT);
 
   /**
    * Maximum time to wait on disconnect
@@ -154,9 +158,20 @@ Advice.prototype = {
     return withinRange(pingInterval, MIN_PING_INTERVAL, MAX_PING_INTERVAL);
   },
 
-  getConnectTimeout: function() {
+  // This represents the amount of time allocated for a
+  // ``/meta/connect` message request-response cycle
+  // taking into account network latency
+  getConnectResponseTimeout: function() {
     var padding = Math.min(this.connectTimeoutPadding, this.timeout / 4);
     return this.timeout + padding;
+  },
+
+  getEstablishTimeout: function() {
+    // Upper-bound is either a minute, or three-quarters of the timeout value,
+    // whichever is lower
+    return withinRange(this.establishTimeout,
+        MIN_ESTABLISH_TIMEOUT,
+        Math.min(MAX_ESTABLISH_TIMEOUT, this.timeout * 0.75));
   }
 
 };

--- a/lib/protocol/advice.js
+++ b/lib/protocol/advice.js
@@ -13,7 +13,7 @@ var DEFAULT_RETRY_INTERVAL = 1000;
 var DEFAULT_CONNECT_TIMEOUT_PADDING = 500;
 
 var ADVICE_HANDSHAKE = 'handshake';
-var ADVICE_RETRY = 'retry'; 
+var ADVICE_RETRY = 'retry';
 var ADVICE_NONE = 'none';
 
 /**

--- a/lib/protocol/client.js
+++ b/lib/protocol/client.js
@@ -471,7 +471,7 @@ Client.prototype = {
     var connect = this._connect = this._sendMessage({
         channel: Channel.CONNECT
       }, {
-        timeout: this._advice.getConnectTimeout()
+        timeout: this._advice.getConnectResponseTimeout()
       })
       .bind(this)
       .then(validateBayeuxResponse)

--- a/lib/protocol/client.js
+++ b/lib/protocol/client.js
@@ -14,6 +14,7 @@ var globalEvents      = require('../util/global-events');
 var Advice            = require('./advice');
 var cancelBarrier     = require('../util/promise-util').cancelBarrier;
 var SubscribeThenable = require('./subscribe-thenable');
+
 var MANDATORY_CONNECTION_TYPES = ['long-polling'];
 var DEFAULT_ENDPOINT = '/bayeux';
 
@@ -104,6 +105,7 @@ function Client(endpoint, options) {
   this._dispatcher = options.dispatcher || new Dispatcher(this._endpoint, advice, options);
   this._initialConnectionTypes = options.connectionTypes || MANDATORY_CONNECTION_TYPES;
   this._messageId = 0;
+  this._connected = false;
 
   /**
    * How many times have we failed handshaking
@@ -125,15 +127,10 @@ function Client(endpoint, options) {
       .done();
   });
 
-  this.listenTo(this._dispatcher, 'transport:down', function() {
-    debug('Connection down');
-    this.trigger('connection:down');
+  this.listenTo(this._dispatcher, 'transport:up transport:down', function() {
+    this._updateConnectionState();
   });
 
-  this.listenTo(this._dispatcher, 'transport:up', function() {
-    debug('Connection up');
-    this.trigger('connection:up');
-  });
 }
 
 Client.prototype = {
@@ -242,6 +239,21 @@ Client.prototype = {
       .then(validateBayeuxResponse);
   },
 
+  _updateConnectionState: function() {
+    // The client is connected when the state
+    // of the client is CONNECTED and the
+    // transport is up
+    var isConnected = this.stateIs('CONNECTED') && this._dispatcher.isTransportUp();
+    if (this._connected === isConnected) return;
+    this._connected = isConnected;
+
+    this.trigger(isConnected ? 'connection:up' : 'connection:down');
+  },
+
+  onStateChange: function() {
+    this._updateConnectionState();
+  },
+
   /**
    * The client must issue a handshake with the server
    */
@@ -290,7 +302,6 @@ Client.prototype = {
    */
   _onEnterCONNECTED: function() {
     this.trigger('connected');
-
     /* Handshake success, reset count */
     this._advice.handshakeSuccess();
 

--- a/lib/protocol/dispatcher.js
+++ b/lib/protocol/dispatcher.js
@@ -161,7 +161,7 @@ Dispatcher.prototype = {
         debug('attemptSend: %j', message);
 
         return transport.sendMessage(message)
-          .timeout(this._advice.getEstablishTimeout(), 'Timeout on message send');
+          .timeout(timeout, 'Timeout on message send');
       })
       .catch(function(e) {
         this._triggerDown();

--- a/lib/protocol/dispatcher.js
+++ b/lib/protocol/dispatcher.js
@@ -296,6 +296,10 @@ Dispatcher.prototype = {
     }
 
     this._pool.down(transport);
+  },
+
+  isTransportUp: function() {
+    return this._state === STATE_UP;
   }
 };
 

--- a/lib/protocol/dispatcher.js
+++ b/lib/protocol/dispatcher.js
@@ -161,7 +161,7 @@ Dispatcher.prototype = {
         debug('attemptSend: %j', message);
 
         return transport.sendMessage(message)
-          .timeout(this._advice.getConnectTimeout(), 'Timeout on message send');
+          .timeout(this._advice.getEstablishTimeout(), 'Timeout on message send');
       })
       .catch(function(e) {
         this._triggerDown();

--- a/lib/transport/base-websocket.js
+++ b/lib/transport/base-websocket.js
@@ -147,7 +147,7 @@ extend(WebSocketTransport.prototype, {
 
     }.bind(this))
     .bind(this)
-    .timeout(this._advice.connectTimeout, 'Websocket connect timeout')
+    .timeout(this._advice.getEstablishTimeout(), 'Websocket connect timeout')
     .then(function(socket) {
       // Connect success, setup listeners
       this._pingTimer = setTimeout(this._pingInterval.bind(this), this._advice.getPingInterval());

--- a/lib/transport/node/node-http.js
+++ b/lib/transport/node/node-http.js
@@ -10,8 +10,9 @@ var Promise           = require('bluebird');
 function NodeHttpTransport(dispatcher, endpoint, advice) {
   NodeHttpTransport.super_.call(this, dispatcher, endpoint, advice);
 
-  this._endpointSecure = this.endpoint.protocol === 'https:';
-  this._httpClient     = this._endpointSecure ? https : http;
+  this._advice       = advice;
+  var endpointSecure = this.endpoint.protocol === 'https:';
+  this._httpClient   = endpointSecure ? https : http;
 }
 inherits(NodeHttpTransport, BatchingTransport);
 
@@ -21,14 +22,13 @@ extend(NodeHttpTransport.prototype, {
   },
 
   request: function(messages) {
+
     return new Promise(function(resolve, reject, onCancel) {
+      var self    = this;
       var content = new Buffer(this.encode(messages), 'utf8');
       var params  = this._buildParams(content);
-      var request = this._httpClient.request(params);
-      var self    = this;
 
-      request.on('response', function(response) {
-
+      var request = this._httpClient.request(params, function(response) {
         var status = response.statusCode;
         var successful = (status >= 200 && status < 300);
         if (successful) {
@@ -61,6 +61,7 @@ extend(NodeHttpTransport.prototype, {
         });
       });
 
+      request.setSocketKeepAlive(true, this._advice.getPingInterval());
       request.on('error', function(error) {
         reject(error);
       });


### PR DESCRIPTION
In Halley, the `connection:up` is fired when the the client is in a state such that if the server were to publish messages for that client, the client would receive them (almost) immediately. `connection:down` means the opposite.

Currently these events are simply proxies on the transport state, but this is a poor implementation. For example, if the client is currently undergoing a handshake, the transport is up, but the connection is down. Only once the client is connected _and_ the transport is up will `connection:up` be reported.
